### PR TITLE
Email field

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -17,6 +17,9 @@ from decimal import Decimal
 from random import randint, choice, random
 
 MAX_LENGTH = 300
+# Using sys.maxint here breaks a bunch of tests when running against a
+# Postgres database.
+maxint = 10000
 
 def gen_from_list(L):
     '''Makes sure all values of the field are generated from the list L
@@ -33,7 +36,7 @@ def gen_from_choices(C):
     choice_list = map(lambda x:x[0], C)
     return gen_from_list(choice_list)
 
-def gen_integer(min_int=-sys.maxint, max_int=sys.maxint):
+def gen_integer(min_int=-maxint, max_int=maxint):
     return randint(min_int, max_int)
 
 gen_float = lambda:random()*gen_integer()
@@ -57,3 +60,5 @@ gen_string.required = ['max_length']
 gen_text = lambda: gen_string(MAX_LENGTH)
 
 gen_boolean = lambda: choice((True, False))
+
+gen_email = lambda: "%s@example.com" % gen_string(10)

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.db.models.fields import AutoField, CharField, TextField
-from django.db.models.fields import DateField, DateTimeField
+from django.db.models.fields import DateField, DateTimeField, EmailField
 from django.db.models.fields import IntegerField, SmallIntegerField
 from django.db.models.fields import PositiveSmallIntegerField, PositiveIntegerField
 from django.db.models.fields import FloatField, DecimalField
@@ -71,6 +71,8 @@ default_mapping = {
 
     DateField:generators.gen_date,
     DateTimeField:generators.gen_date,
+
+    EmailField:generators.gen_email,
 }
 
 class Mommy(object):

--- a/model_mommy/tests/import_helpers.py
+++ b/model_mommy/tests/import_helpers.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from django.db.models.fields import AutoField, CharField, TextField
-from django.db.models.fields import DateField, DateTimeField
+from django.db.models.fields import DateField, DateTimeField, EmailField
 from django.db.models.fields import IntegerField, SmallIntegerField
 from django.db.models.fields import PositiveSmallIntegerField, PositiveIntegerField
 from django.db.models.fields import FloatField, DecimalField
@@ -12,7 +12,7 @@ from django.db.models.fields import BooleanField
 from model_mommy import mommy
 from model_mommy.models import Person, Dog, Store
 from model_mommy.models import DummyIntModel, DummyPositiveIntModel, DummyNumbersModel
-from model_mommy.models import DummyDecimalModel
+from model_mommy.models import DummyDecimalModel, DummyEmailModel
 from model_mommy.generators import gen_from_list
 
 try:

--- a/model_mommy/tests/models.py
+++ b/model_mommy/tests/models.py
@@ -48,3 +48,6 @@ class DummyNumbersModel(models.Model):
 
 class DummyDecimalModel(models.Model):
     decimal_field = models.DecimalField(max_digits=5, decimal_places=2)
+
+class DummyEmailModel(models.Model):
+    email_field = models.EmailField()

--- a/model_mommy/tests/test_filling_fields.py
+++ b/model_mommy/tests/test_filling_fields.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 __all__ = [
     'StringFieldsFilling', 'BooleanFieldsFilling', 'DateTimeFieldsFilling',
     'DateFieldsFilling','FillingIntFields', 'FillingPositiveIntFields',
-    'FillingOthersNumericFields', 'FillingFromChoice'
+    'FillingOthersNumericFields', 'FillingFromChoice', 'FillingEmailField',
 ]
 
 class FieldFillingTestCase(TestCase):
@@ -114,3 +114,10 @@ class FillingOthersNumericFields(TestCase):
 
         self.assertTrue(isinstance(decimal_field, DecimalField))
         self.assertTrue(isinstance(self.dummy_decimal_model.decimal_field, basestring))
+
+class FillingEmailField(TestCase):
+    def test_filling_EmailField(self):
+        obj = mommy.make_one(DummyEmailModel)
+        field = DummyEmailModel._meta.get_field('email_field')
+        self.assertTrue(isinstance(field, EmailField))
+        self.assertTrue(isinstance(obj.email_field, basestring))


### PR DESCRIPTION
Hi Vanderson,

This adds support for EmailField and reduces the range of integer values used on gen_integer() because using sys.maxint causes a bunch of tests to break when running on a Postgres database.  I think we could use a much higher range by default, if you think it's important, but we'd probably want to change the Smallinteger fields to use a smaller one.
