### PR TITLE
Skip GenericRelation fields

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -7,6 +7,8 @@ from django.db.models.fields import FloatField, DecimalField
 from django.db.models.fields import BooleanField
 from django.db.models.fields import URLField
 
+from django.contrib.contenttypes import generic
+
 try:
     from django.db.models.fields import BigIntegerField
 except ImportError:
@@ -114,6 +116,9 @@ class Mommy(object):
             if isinstance(field, AutoField):
                 continue
 
+            if isinstance(field, generic.GenericRelation):
+                continue
+            
             if isinstance(field, ManyToManyField):
                 if field_value_not_defined:
                     if ignore_field(field):


### PR DESCRIPTION
```
class Bookmark(models.Model):
    url = models.URLField()
    tags = generic.GenericRelation(TaggedItem)
```

GenericRelation fields don't need to be filled out. After the patch, model_mommy won't attempt to generate value for "tags" in the example above. 
