### PR TITLE
Included model_mommy/tests in sys.path - fix for issue #21

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -4,7 +4,9 @@ import os
 import sys
 
 parent = os.path.abspath(os.path.dirname(__file__))
+tests_dir = os.path.join(parent, 'model_mommy', 'tests')
 sys.path.insert(0, parent)
+sys.path.insert(0, tests_dir)
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
 


### PR DESCRIPTION
Hi,

The problem with issue #21 is because test_settings.py is under model_mommy/tests, and it is not in sys.path.

I just added two lines to include tests dir in sys.path in runtests.py.
