### PR TITLE
Pass attributes in make_many

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -49,7 +49,7 @@ def prepare_one(model, **attrs):
 
 def make_many(model, qty=5, **attrs):
     mommy = Mommy(model)
-    return [mommy.make_one() for i in range(qty)]
+    return [mommy.make_one(**attrs) for i in range(qty)]
 
 make_one.required = foreign_key_required
 prepare_one.required = foreign_key_required

--- a/model_mommy/tests/test_mommy.py
+++ b/model_mommy/tests/test_mommy.py
@@ -29,6 +29,12 @@ class MommyCreatesSimpleModel(TestCase):
 
         self.assertEqual(person.id, None)
 
+    def test_make_many(self):
+        people = mommy.make_many(Person, qty=5)
+        self.assertEqual(Person.objects.count(), 5)
+
+        people = mommy.make_many(Person, name="George Washington")
+        self.assertTrue(all(p.name == "George Washington" for p in people))
 
 class MommyCreatesAssociatedModels(TestCase):
 


### PR DESCRIPTION
When you call `make_one` in `make_many`, it was never supplied `**attrs`.  This fixes that.

Tests included.
