### PR TITLE
Tweak to _make_one

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -162,7 +162,7 @@ class Mommy(object):
             # If not specified, django automatically sets blank=True and
             # default on BooleanFields so we don't need to check these
             if not isinstance(field, BooleanField):
-                if field.has_default() or field.blank:
+                if (hasattr(field, 'has_default') and field.has_default()) or field.blank:
                     continue
 
             if isinstance(field, ManyToManyField):


### PR DESCRIPTION
Some fields do not have a "has_default" attribute, which crashes the _make_one function in Mommy.  This patch simply checks for the existence of the has_default attribute before calling it.
