### PR TITLE
Force string gen to only use letters avoiding non-printable chars

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -89,7 +89,7 @@ def gen_time():
 
 
 def gen_string(max_length):
-    return ''.join(choice(string.printable) for i in range(max_length))
+    return ''.join(choice(string.ascii_letters) for i in range(max_length))
 gen_string.required = ['max_length']
 
 


### PR DESCRIPTION
Model-mommy generates string values with non-printable chars, which makes very complicated to read tests error messages.
