### PR TITLE
Fixes model_mommy to accept m2m relationships as kwargs

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -238,7 +238,10 @@ class Mommy(object):
                 continue
 
             if isinstance(field, ManyToManyField):
-                self.m2m_dict[field.name] = self.m2m_value(field, model_attrs)
+                if field.name not in model_attrs:
+                    self.m2m_dict[field.name] = self.m2m_value(field)
+                else:
+                    self.m2m_dict[field.name] = model_attrs.pop(field.name)
             elif field_value_not_defined:
                 if field.null:
                     continue
@@ -247,16 +250,11 @@ class Mommy(object):
 
         return self.instance(model_attrs, _commit=commit)
 
-    def m2m_value(self, field, attrs):
-        if field.name not in attrs:
-            if not self.make_m2m or field.null:
-                value =  []
-            else:
-                value = self.generate_value(field)
+    def m2m_value(self, field):
+        if not self.make_m2m or field.null:
+            return []
         else:
-            value = model_attrs.pop(field.name)
-
-        return value
+            return self.generate_value(field)
 
     def instance(self, attrs, _commit):
         instance = self.model(**attrs)

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -153,6 +153,16 @@ class MommyCreatesAssociatedModels(TestCase):
         self.assertEqual(store.employees.count(), 5)
         self.assertEqual(store.customers.count(), 5)
 
+    def test_regresstion_many_to_many_field_is_accepted_as_kwargs(self):
+        employees = mommy.make(Person, _quantity=3)
+        customers = mommy.make(Person, _quantity=3)
+
+        store = mommy.make(Store, employees=employees, customers=customers)
+
+        self.assertEqual(store.employees.count(), 3)
+        self.assertEqual(store.customers.count(), 3)
+        self.assertEqual(Person.objects.count(), 6)
+
     def test_create_many_to_many_with_set_default_quantity(self):
         store = mommy.make(Store)
         self.assertEqual(store.employees.count(), mommy.MAX_MANY_QUANTITY)


### PR DESCRIPTION
There is a bug which the following input was valid once but now it is raising the following error and this bug was created by me on a previous PR (shame on me) and this PR fixex it:

``` python
employees = mommy.make(Person, _quantity=3)
customers = mommy.make(Person, _quantity=3)
store = mommy.make(Store, employees=employees, customers=customers)
.....
NameError: global name 'model_attrs' is not defined
```
