### PR TITLE
Fixes #108 -- Improve detection of generator function for custom fields.

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -15,9 +15,7 @@ from decimal import Decimal
 from os.path import abspath, join, dirname
 from random import randint, choice, random
 from django import VERSION
-from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
-from django.db.models import get_models
 
 from model_mommy.timezone import now
 
@@ -117,4 +115,6 @@ def gen_email():
 
 
 def gen_content_type():
+    from django.contrib.contenttypes.models import ContentType
+    from django.db.models import get_models
     return ContentType.objects.get_for_model(choice(get_models()))

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -317,6 +317,44 @@ class Mommy(object):
             generator = self.type_mapping[ContentType]
         elif field.__class__ in self.type_mapping:
             generator = self.type_mapping[field.__class__]
+        elif isinstance(field, ManyToManyField):
+            generator = __m2m_generator
+        elif isinstance(field, BooleanField):
+            generator = generators.gen_boolean
+        elif isinstance(field, ContentType):
+            generator = generators.gen_content_type
+        elif isinstance(field, DateField):
+            generator = generators.gen_date
+        elif isinstance(field, DateTimeField):
+            generator = generators.gen_datetime
+        elif isinstance(field, DecimalField):
+            generator = generators.gen_decimal
+        elif isinstance(field, EmailField):
+            generator = generators.gen_email
+        elif isinstance(field, FileField):
+            generator = generators.gen_file_field
+        elif isinstance(field, FloatField):
+            generator = generators.gen_float
+        elif isinstance(field, ImageField):
+            generator = generators.gen_image_field
+        elif isinstance(field, (BigIntegerField, IntegerField, SmallIntegerField)):
+            generator = generators.gen_integer
+        elif isinstance(field, SlugField):
+            generator = generators.gen_slug
+        elif isinstance(field, CharField):
+            generator = generators.gen_string
+        elif isinstance(field, TextField):
+            generator = generators.gen_text
+        elif isinstance(field, TimeField):
+            generator = generators.gen_time
+        elif isinstance(field, URLField):
+            generator = generators.gen_url
+        elif isinstance(field, (PositiveIntegerField, PositiveSmallIntegerField)):
+            generator = lambda: generators.gen_integer(0)
+        elif isinstance(field, ForeignKey):
+            generator = make
+        elif isinstance(field, OneToOneField):
+            generator = make
         else:
             raise TypeError('%s is not supported by mommy.' % field.__class__)
 

--- a/test/generic/fields.py
+++ b/test/generic/fields.py
@@ -3,5 +3,5 @@ from django.db import models
 class CustomFieldWithGenerator(models.TextField):
     pass
 
-class CustomFieldWithoutGenerator(models.TextField):
+class CustomFieldWithoutGenerator(models.Field):
     pass


### PR DESCRIPTION
Use `isinstance()` to detect compatible field subclasses. Avoid circular
import when mapping built-in generators to custom fields in settings.
