### PR TITLE
Removes the platform dependence in tests

### DIFF
--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -5,6 +5,7 @@
 # DO NOT ADD THE APP TO INSTALLED_APPS#
 #######################################
 from decimal import Decimal
+from tempfile import gettempdir
 
 from django.db import models
 from django.core.files.storage import FileSystemStorage
@@ -138,12 +139,12 @@ class DummyDefaultFieldsModel(models.Model):
 
 
 class DummyFileFieldModel(models.Model):
-    fs = FileSystemStorage(location='/tmp/')
+    fs = FileSystemStorage(location=gettempdir())
     file_field = models.FileField(upload_to="%Y/%m/%d", storage=fs)
 
 
 class DummyImageFieldModel(models.Model):
-    fs = FileSystemStorage(location='/tmp/')
+    fs = FileSystemStorage(location=gettempdir())
     image_field = models.ImageField(upload_to="%Y/%m/%d", storage=fs)
 
 class DummyMultipleInheritanceModel(DummyDefaultFieldsModel, Person):

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, time
 from decimal import Decimal
+from os.path import abspath
+from tempfile import gettempdir
 
 from django.test import TestCase
 from django.conf import settings
@@ -227,11 +229,11 @@ class FillingFileField(TestCase):
         field = DummyFileFieldModel._meta.get_field('file_field')
         self.assertIsInstance(field, FileField)
         import time
-        path = "/tmp/%s/mock_file.txt" % time.strftime('%Y/%m/%d')
+        path = "%s/%s/mock_file.txt" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
         from django import VERSION
         if VERSION[1] >= 4:
-            self.assertEqual(self.dummy.file_field.path, path)
+            self.assertEqual(abspath(self.dummy.file_field.path), abspath(path))
 
     def tearDown(self):
         self.dummy.file_field.delete()
@@ -248,11 +250,11 @@ class FillingImageFileField(TestCase):
         field = DummyImageFieldModel._meta.get_field('image_field')
         self.assertIsInstance(field, ImageField)
         import time
-        path = "/tmp/%s/mock-img.jpeg" % time.strftime('%Y/%m/%d')
+        path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
         from django import VERSION
         if VERSION[1] >= 4:
-            self.assertEqual(self.dummy.image_field.path, path)
+            self.assertEqual(abspath(self.dummy.image_field.path), abspath(path))
         self.assertTrue(self.dummy.image_field.width)
         self.assertTrue(self.dummy.image_field.height)
 


### PR DESCRIPTION
The `FileField` and `ImageField` tests currently assume the existence of
a UNIX-style temp directory and the use of UNIX-style paths. On
Windows this causes the tests to fail and to create spurious new
files and directories.

This commit makes the tests platform-independent by using the
standard Python modules `tempfile` and `os.path`.
