### PR TITLE
Fixed #113 - a unique vaildation error might be thrown if a to-be created instance exists.

### DIFF
--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from tempfile import gettempdir
 
 from django.db import models
+from django.db.models.signals import post_save
 from django.core.files.storage import FileSystemStorage
 
 from django.contrib.contenttypes.models import ContentType
@@ -68,6 +69,10 @@ class Dog(models.Model):
 
 class LonelyPerson(models.Model):
     only_friend = models.OneToOneField(Person)
+
+
+class LonelyPersonWithPostSaveHook(models.Model):
+    only_friend = models.OneToOneField(User)
 
 
 class Store(models.Model):
@@ -192,3 +197,13 @@ class CustomFieldWithoutGeneratorModel(models.Model):
 
 class DummyUniqueIntegerFieldModel(models.Model):
     value = models.IntegerField(unique=True)
+
+
+def lonely_user_with_post_save_hook(sender, instance, created, **kwargs):
+    """Create a person when a new user account is created"""
+    if created:
+        lp = LonelyPersonWithPostSaveHook()
+        lp.only_friend = instance
+        lp.save()
+
+post_save.connect(lonely_user_with_post_save_hook, sender=User)

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -10,7 +10,9 @@ from mock import patch, Mock
 from model_mommy import mommy
 from model_mommy.exceptions import ModelNotFound, AmbiguousModelName, InvalidQuantityException
 from model_mommy.timezone import smart_datetime as datetime
-from test.generic.models import Person, Dog, Store, LonelyPerson, School, SchoolEnrollment, ModelWithImpostorField
+from test.generic.models import (Person, Dog, Store, LonelyPerson, School,
+                                 SchoolEnrollment, ModelWithImpostorField,
+                                 LonelyPersonWithPostSaveHook)
 from test.generic.models import User, PaymentBill
 from test.generic.models import UnsupportedModel, DummyGenericRelationModel
 from test.generic.models import DummyNullFieldsModel, DummyBlankFieldsModel
@@ -174,6 +176,13 @@ class MommyCreatesAssociatedModels(TestCase):
         self.assertEquals(LonelyPerson.objects.all().count(), 1)
         self.assertTrue(isinstance(lonely_person.only_friend, Person))
         self.assertEquals(Person.objects.all().count(), 1)
+
+    def test_create_with_post_save_hook(self):
+        lonely_person = mommy.make(LonelyPersonWithPostSaveHook)
+
+        self.assertEquals(LonelyPersonWithPostSaveHook.objects.count(), 1)
+        self.assertTrue(isinstance(lonely_person.only_friend, User))
+        self.assertEquals(User.objects.count(), 1)
 
     def test_create_many_to_many_if_flagged(self):
         store = mommy.make(Store, make_m2m=True)


### PR DESCRIPTION
``` python
class LonelyPersonWithPostSaveHook(models.Model):
    only_friend = models.OneToOneField(User) 

def lonely_user_with_post_save_hook(sender, instance, created, **kwargs):
    """Create a person when a new user account is created"""
    if created:
        lp = LonelyPersonWithPostSaveHook()
        lp.only_friend = instance
        lp.save()

post_save.connect(lonely_user_with_post_save_hook, sender=User)

mommy.make(LonelyPersonWithPostSaveHook)     # used to throw unique validation error in Mommy.instance()
```

This pull request fixes this behaviour (tests included).
