### PR TITLE
Feature/custom field value generation api #90

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,7 @@ If you have fields with special validation, you should set their values by yours
 *Model-mommy* should handle fields that:
 
 1. don't matter for the test you're writing;
-2. don't require special validation (like unique, etc);
-3. are required to create the object.
+2. are required to create the object.
 
 
 Currently supported fields
@@ -170,17 +169,17 @@ Currently supported fields
 Custom fields
 -------------
 
-Model-mommy allows you to define generators methods for your custom fields or overrides its default generators. This could be achieved by specifing a dict on settings that its keys are the field paths and the values their generators functions, as the example bellow:
+Model-mommy allows you to specify your own value generators. You can use this to
+
+ * provide support for your custom fields
+ * override the default generators, on fields that require special validation
 
 .. code-block:: python
 
-    # on your settings.py file:
     def gen_func():
         return 'value'
 
-    MOMMY_CUSTOM_FIELDS_GEN = {
-        'test.generic.fields.CustomField': gen_func,
-    }
+    mommy.add_value_generator(gen_func, CustomField)
 
 
 Recipes

--- a/README.rst
+++ b/README.rst
@@ -171,8 +171,7 @@ Custom fields
 
 Model-mommy allows you to specify your own value generators. You can use this to
 
- * provide support for your custom fields
- * override the default generators, on fields that require special validation
+* provide support for your own or 3rd party custom fields
 
 .. code-block:: python
 
@@ -180,6 +179,21 @@ Model-mommy allows you to specify your own value generators. You can use this to
         return 'value'
 
     mommy.add_value_generator(gen_func, CustomField)
+
+* override the custom generator on a specific model
+
+.. code-block:: python
+
+   mommy.add_value_generator(lambda: 'some other value', CustomField, MyModel)
+
+* temporarily override the custom generator specified in a context
+
+.. code-block:: python
+
+  with mommy.add_value_generator(lambda: 'temp', CustomField):
+      ... 'temp' will be assigned to CustomFields
+
+  ... whatever generator was used before the context is restored
 
 
 Recipes

--- a/model_mommy/__init__.py
+++ b/model_mommy/__init__.py
@@ -1,5 +1,5 @@
 #coding:utf-8
-__version__ = '1.0'
+__version__ = '1.1'
 __title__ = 'model_mommy'
 __author__ = 'Vanderson Mota'
 __license__ = 'Apache 2.0'

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import warnings
 
-from django.conf import settings
+from collections import defaultdict
 from django.utils import importlib
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
@@ -23,6 +23,7 @@ except ImportError:
 
 import generators
 from exceptions import ModelNotFound, AmbiguousModelName, InvalidQuantityException
+
 
 from six import string_types
 
@@ -143,6 +144,7 @@ default_mapping = {
     ContentType: generators.gen_content_type,
 }
 
+custom_mapping = defaultdict(dict)
 
 class ModelFinder(object):
     '''
@@ -229,11 +231,8 @@ class Mommy(object):
 
     def init_type_mapping(self):
         self.type_mapping = default_mapping.copy()
-        generator_from_settings = getattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', {})
-        for k, v in generator_from_settings.items():
-            path, field_name = k.rsplit('.', 1)
-            field_class = getattr(importlib.import_module(path), field_name)
-            self.type_mapping[field_class] = v
+        self.type_mapping.update(custom_mapping[None])
+        self.type_mapping.update(custom_mapping[self.model])
 
     def make(self, **attrs):
         '''Creates and persists an instance of the model
@@ -418,3 +417,11 @@ def make_many_from_recipe(mommy_recipe_name, quantity=None, **new_attrs):
     warnings.warn(msg, DeprecationWarning)
     quantity = quantity or MAX_MANY_QUANTITY
     return [make_recipe(mommy_recipe_name, **new_attrs) for x in range(quantity)]
+
+
+def add_value_generator(generator, field, model=None):
+    custom_mapping[model][field] = generator
+
+
+def clear_value_generators():
+    custom_mapping.clear()

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -406,8 +406,21 @@ def filter_rel_attrs(field_name, **rel_attrs):
     return clean_dict
 
 
-def add_value_generator(generator, field, model=None):
-    custom_mapping[model][field] = generator
+class add_value_generator(object):
+
+    def __init__(self, generator, field, model=None):
+        self._model = model
+        self._field = field
+        self.original = custom_mapping[model].get(field, None)
+        custom_mapping[model][field] = generator
+
+    def __enter__(self):
+        return self.original
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        del custom_mapping[self._model][self._field]
+        if self.original:
+            custom_mapping[self._model][self._field] = self.original
 
 
 def clear_value_generators():

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -182,7 +182,11 @@ class NonAbstractPerson(Person):
     dummy_count = models.IntegerField()
 
 
-class CustomFieldWithGeneratorModel(models.Model):
+class ModelWithCustomField(models.Model):
+    custom_value = CustomFieldWithGenerator()
+
+
+class AnotherModelWithCustomField(models.Model):
     custom_value = CustomFieldWithGenerator()
 
 

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -303,6 +303,23 @@ class FillingCustomFields(TestCase):
         obj = mommy.make(AnotherModelWithCustomField)
         self.assertEqual("specific", obj.custom_value)
 
+    def test_can_add_a_generator_in_a_context(self):
+        with mommy.add_value_generator(lambda: "temp",
+                                       CustomFieldWithGenerator):
+            obj = mommy.make(ModelWithCustomField)
+            self.assertEqual("temp", obj.custom_value)
+        self.assertRaises(TypeError, mommy.make, ModelWithCustomField)
+
+    def test_original_generater_is_restored_after_context(self):
+        mommy.add_value_generator(lambda: "default",
+                                  CustomFieldWithGenerator)
+        with mommy.add_value_generator(lambda: "temp",
+                                       CustomFieldWithGenerator):
+            obj = mommy.make(ModelWithCustomField)
+            self.assertEqual("temp", obj.custom_value)
+        obj = mommy.make(ModelWithCustomField)
+        self.assertEqual("default", obj.custom_value)
+
 
 class FillingCustomFieldsTheDeprecatedWay(TestCase):
 


### PR DESCRIPTION
Started some code on a feature branch. Needs more work and discussion.
Doing a pull_request for further discussion following #90.

Not sure about the decorators. They don't really make sense, as we aren't really wrapping the fields.
```python
def gen_func():
    return "random_value"

class CustomField(models.Fields):
    ... #some field code

add_value_generator(gen_func, CustomField)
```
Is the same LOC. But make more sense semantically, than

```python
def gen_func():
    return "random_value"

@custom_field_gen("gen_func")
class CustomField(models.Fields):
    ... #some field code
```


I do still see a usecase for the context_manager as it is better at handling exception cases than a `single_use` parameter would.

And what about a model_field param? When I did the model param, I thought, about a model using the same CustomField multiple times for different model_fields. But when implementing that, I felt like I was redoing stuff, that can already be done pretty well with recipes.