### PR TITLE
Refactored Sequence, added IterableSequence

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -23,28 +23,11 @@ except ImportError:
 
 import generators
 from exceptions import ModelNotFound, AmbiguousModelName, InvalidQuantityException
+from sequences import BaseSequence
 
 from six import string_types
 
-
-class Sequence(object):
-
-    def __init__(self, value, increment_by=1):
-        self.value = value
-        self.counter = increment_by
-        self.increment_by = increment_by
-
-    def get_inc(self, model):
-        if not model.objects.count():
-            self.counter = self.increment_by
-        i = self.counter
-        self.counter += self.increment_by
-        return i
-
-    def gen(self, model):
-        inc = self.get_inc(model)
-        return self.value + type(self.value)(inc)
-
+from sequences import Sequence  # only for backward compatibility
 
 recipes = None
 
@@ -275,7 +258,7 @@ class Mommy(object):
                     continue
                 else:
                     model_attrs[field.name] = self.generate_value(field)
-            elif isinstance(model_attrs[field.name], Sequence):
+            elif isinstance(model_attrs[field.name], BaseSequence):
                 model_attrs[field.name] = model_attrs[field.name].gen(self.model)
 
         return self.instance(model_attrs, _commit=commit)

--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -62,7 +62,7 @@ def foreign_key(recipe):
     """
     return RecipeForeignKey(recipe)
 
-def seq(value, increment_by=1):
-    return mommy.Sequence(value, increment_by=increment_by)
+def seq(value, *args, **kwargs):
+    return mommy.Sequence(value, *args, **kwargs)
 
 

--- a/model_mommy/sequences.py
+++ b/model_mommy/sequences.py
@@ -1,0 +1,51 @@
+import collections
+
+
+class BaseSequence(object):
+    def gen(self, model):
+        raise NotImplementedError('Please use a subclass instead.')
+
+
+class IncrementalSequence(BaseSequence):
+    def __init__(self, value, increment_by=1):
+        self.value = value
+        self.counter = increment_by
+        self.increment_by = increment_by
+
+    def get_inc(self, model):
+        if not model.objects.count():
+            self.counter = self.increment_by
+        i = self.counter
+        self.counter += self.increment_by
+        return i
+
+    def gen(self, model):
+        inc = self.get_inc(model)
+        return self.value + type(self.value)(inc)
+
+incr = IncrementalSequence
+
+
+class IterableSequence(BaseSequence):
+    def __init__(self, values):
+        self.values = values
+        self._counter = 0
+
+    def gen(self, model):
+        if self._counter >= len(self.values):
+            self._counter = 0
+        self._counter += 1
+        return self.values[self._counter-1]
+
+itera = IterableSequence
+
+
+class Sequence(BaseSequence):
+    def __init__(self, value, *args, **kwargs):
+        if not isinstance(value, basestring) and isinstance(value, collections.Iterable):
+            self.seq = itera(value, *args, **kwargs)
+        else:
+            self.seq = incr(value, *args, **kwargs)
+
+    def gen(self, model):
+        return self.seq.gen(model)

--- a/test/generic/tests/__init__.py
+++ b/test/generic/tests/__init__.py
@@ -3,3 +3,4 @@ from test_mommy import *
 from test_extending_mommy import *
 from test_filling_fields import *
 from test_recipes import *
+from test_sequences import *

--- a/test/generic/tests/test_sequences.py
+++ b/test/generic/tests/test_sequences.py
@@ -1,0 +1,130 @@
+#coding: utf-8
+
+from decimal import Decimal
+from django.test import TestCase
+from model_mommy import mommy
+from model_mommy.recipe import Recipe, foreign_key, RecipeForeignKey
+from model_mommy.timezone import now
+from model_mommy.exceptions import InvalidQuantityException
+from test.generic.models import Person, DummyNumbersModel, DummyBlankFieldsModel, Dog
+
+
+from model_mommy.sequences import incr, itera, Sequence
+
+
+class TestIncrementalSequence(TestCase):
+    def test_integer(self):
+        people = mommy.make(Person, name=incr(1), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['2', '3', '4']
+        )
+
+    def test_integer_increment_by(self):
+        people = mommy.make(Person, name=incr(1, increment_by=2), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['3', '5', '7']
+        )
+
+    def test_string(self):
+        people = mommy.make(Person, name=incr('test'), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['test1', 'test2', 'test3']
+        )
+
+    def test_string_increment_by(self):
+        people = mommy.make(Person, name=incr('test', increment_by=2), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['test2', 'test4', 'test6']
+        )
+
+
+class TestIterableSequence(TestCase):
+    def test_list(self):
+        names = ['Alice', 'Bob', 'Cris']
+
+        # matching args
+        people = mommy.make(Person, name=itera(names), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), names
+        )
+
+        Person.objects.all().delete()
+
+        # mismatching args
+        people = mommy.make(Person, name=itera(names), _quantity=5)
+        self.assertEqual(Person.objects.count(), 5)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True),
+            ['Alice', 'Bob', 'Cris', 'Alice', 'Bob']
+        )
+
+    def test_tuple(self):
+        names = ('Alice', 'Bob', 'Cris')
+
+        # matching args
+        people = mommy.make(Person, name=itera(names), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), names
+        )
+
+        Person.objects.all().delete()
+
+        # mismatching args
+        people = mommy.make(Person, name=itera(names), _quantity=5)
+        self.assertEqual(Person.objects.count(), 5)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True),
+            ['Alice', 'Bob', 'Cris', 'Alice', 'Bob']
+        )
+
+    def test_string(self):
+        names = 'abc'
+
+        # matching args
+        people = mommy.make(Person, name=itera(names), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['a', 'b', 'c']
+        )
+
+        Person.objects.all().delete()
+
+        # mismatching args
+        people = mommy.make(Person, name=itera(names), _quantity=5)
+        self.assertEqual(Person.objects.count(), 5)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True),
+            ['a', 'b', 'c', 'a', 'b']
+        )
+
+
+class TestSequence(TestCase):
+    def test_list(self):
+        names = ['Alice', 'Bob', 'Cris']
+
+        # matching args
+        people = mommy.make(Person, name=Sequence(names), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), names
+        )
+
+    def test_string(self):
+        people = mommy.make(Person, name=Sequence('test', increment_by=2), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['test2', 'test4', 'test6']
+        )
+
+    def test_integer(self):
+        people = mommy.make(Person, name=Sequence(1, increment_by=2), _quantity=3)
+        self.assertEqual(Person.objects.count(), 3)
+        self.assertItemsEqual(
+            Person.objects.values_list('name', flat=True), ['3', '5', '7']
+        )


### PR DESCRIPTION
I was in the same situation discussed in #103 so I started refactoring the sequence logic.

I would like to change a few small things before you can merge but I wanted to know what you thought first.
Below changes and questions:
- Sequences is now a new module. There's a small backward compatibility to take into account `mommy.Sequence` which _might_ print a warning as it would be better to import directly from sequences.
- `IterableSequence` takes an iterable as argument. If there is a mismatch between args numbers, the Sequence starts from the beginning. I think it's a nice shortcut (e.g. use `['odd', 'even']` and have them cycle).
- The `Sequence` object is a bit magic because it does different things depending on the type of the value passed. It would be better to use the explicit sequence types from now on and change the documentation so that people can get used to it.
- Finally, I'm not so happy about the names `incr` and `itera` but it would be good to have shortcuts to make them easier to use.

I would need to change the documentation as well at a certain point.
