### PR TITLE
TaggableManager from django-taggit fails in model creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,16 @@ Model-mommy allows you to define generators methods for your custom fields or ov
         'test.generic.fields.CustomField': gen_func,
     }
 
+django-taggit
+-------------
+
+Model-mommy identifies django-taggit's `TaggableManager` as a normal Django field, which can lead to errors:
+
+.. code-block:: pycon
+
+    TypeError: <class 'taggit.managers.TaggableManager'> is not supported by mommy.
+
+The fix for this is to set ``blank=True`` on your ``TaggableManager``.
 
 Recipes
 =======


### PR DESCRIPTION
This is related to #89, but it looks like recent versions of taggit's `TaggableManager` now subclasses `Field` and provides `has_default() == False`.

```
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:75: in make
>           return mommy.make(**attrs)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:241: in make
>       return self._make(commit=True, **attrs)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:277: in _make
>                   model_attrs[field.name] = self.generate_value(field)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:351: in generate_value
>       return generator(**generator_attrs)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:75: in make
>           return mommy.make(**attrs)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:241: in make
>       return self._make(commit=True, **attrs)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:277: in _make
>                   model_attrs[field.name] = self.generate_value(field)
../../.virtualenvs/dashboard/lib/python2.7/site-packages/model_mommy/mommy.py:342: in generate_value
>           raise TypeError('%s is not supported by mommy.' % field.__class__)
E           TypeError: <class 'taggit.managers.TaggableManager'> is not supported by mommy.
```

I can't provide a generator function for a custom field either, because the tags cannot be set from the model constructor.

I don't see an easy way to identify this kind of fake field. :/
