### PR TITLE
Fixing callables on model_mommy Recipe.

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -277,6 +277,8 @@ class Mommy(object):
                     model_attrs[field.name] = self.generate_value(field)
             elif isinstance(model_attrs[field.name], Sequence):
                 model_attrs[field.name] = model_attrs[field.name].gen(self.model)
+            elif callable(model_attrs[field.name]):
+                model_attrs[field.name] = model_attrs[field.name]()
 
         return self.instance(model_attrs, _commit=commit)
 

--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -18,8 +18,6 @@ class Recipe(object):
             # do not generate values if field value is provided
             if new_attrs.get(k):
                 continue
-            if callable(v):
-                mapping[k] = v()
             elif isinstance(v, RecipeForeignKey):
                 a={}
                 for key, value in list(rel_fields_attrs.items()):

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -74,6 +74,15 @@ class TestDefiningRecipes(TestCase):
             r.make().blank_char_field
             self.assertEqual(choice_mock.call_count, 2)
 
+    def test_always_calls_with_quantity(self):
+        with patch('test.generic.tests.test_recipes.choice') as choice_mock:
+            l = ['foo', 'bar', 'spam', 'eggs']
+            r = Recipe(DummyBlankFieldsModel,
+                blank_char_field = lambda: choice(l)
+            )
+            r.make(_quantity=3)
+            self.assertEqual(choice_mock.call_count, 3)
+
     def test_make_recipes_with_args(self):
         """
           Overriding some fields values at recipe execution


### PR DESCRIPTION
This commit addresses an issue with how callables were handled in model_mommy's
Recipe class. Previously, callables were detected and resolved on the `_make`
method of the Recipe class. This caused problems for things like the `_quantity`
api, since subsequent calls to mommy.make would just return the same value that
was first resolved in `_make`. If you tried to introduce randomness into your
mommy generations, you'd find this to be impossible via Recipe and _quantity.

Here is an example that highlights this issue:

``` python
from random import choice

from model_mommy import mommy
from model_mommy.recipe import Recipe, seq

FIRSTNAMES = ['Joe', 'Shirly', 'Adam', 'Carol', 'Mason', 'Jane']
LASTNAMES = ['Bourque', 'Neely', 'Moog', 'Esposito', 'Orr', 'Oates']

user_recipe = Recipe('auth.User',
    username = seq('user'),
    first_name = lambda: choice(FIRSTNAMES),
    last_name = lambda: choice(LASTNAMES)
)

users = user_recipe.make(_quantity=3)
for user in users:
    print "User: %s First: %s Last: %s" % (user.username,
        user.first_name, user.last_name)
```

Results in:

```
User: user1 First: Jane Last: Esposito
User: user2 First: Jane Last: Esposito
User: user3 First: Jane Last: Esposito
```

This PR address the problem and guarantees that the lambda is called each time `make` is called.
