### PR TITLE
Updating TravisCI to run against latest Django versions (1.3.7/1.4.10/1.5.5/1.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: python
 python:
   - "2.7"
 env:
-  - DJANGO_VERSION=1.2.7
-  - DJANGO_VERSION=1.3.1
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5.1
+  - DJANGO_VERSION=1.3.7
+  - DJANGO_VERSION=1.4.10
+  - DJANGO_VERSION=1.5.5
+  - DJANGO_VERSION=1.6
 matrix:
   include:
     - python: 3.3
-      env: DJANGO_VERSION=1.5.1
+      env: DJANGO_VERSION=1.6
   allow_failures:
     - python: 3.3
-      env: DJANGO_VERSION=1.5.1
+      env: DJANGO_VERSION=1.6
 before_install:
   - sudo apt-get update && sudo apt-get build-dep python-imaging
 install:


### PR DESCRIPTION
1.2 hasn't been supported in quite some time so I removed tests there (willing to add them back of course), 1.3/1.4/1.5 needed the latest point releases and 1.6 needed to be added to the mix.

Worth looking into adding 2.6 testing as well.
