### PR TITLE
Imports moved to allow use built-in generators in settings

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -15,9 +15,7 @@ from decimal import Decimal
 from os.path import abspath, join, dirname
 from random import randint, choice, random
 from django import VERSION
-from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
-from django.db.models import get_models
 
 from model_mommy.timezone import now
 
@@ -117,4 +115,7 @@ def gen_email():
 
 
 def gen_content_type():
+    from django.contrib.contenttypes.models import ContentType
+    from django.db.models import get_models
+
     return ContentType.objects.get_for_model(choice(get_models()))


### PR DESCRIPTION
"Imports moved to allow use built-in generators in settings (import uses settings)"

Mostly of my custom fields are based in subclass of standard Django fields, so i tried:

```
from model_mommy import generators

MOMMY_CUSTOM_FIELDS_GEN = {
    'app.models.MyCharField': generators.gen_string,
}
```

But exist one problem here: I'll be importing on settings a function from model mommy and the same depends on the settings, so when model mommy tries import the settings during my import on settings.py the same is not configured and raises an error.

```
Error occurs after starting the tests in django, with DATABASES and MOMMY_CUSTOM_FIELDS_GEN 
in local_settings. It tries to load the database, but the same has not been loaded yet and 
throws an exception.
```
