### PR TITLE
Prevent prepare from persisting an instance for a related OneToOneField

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -258,6 +258,7 @@ class Mommy(object):
         '''Creates, but do not persists, an instance of the model
         associated with Mommy instance.'''
         self.type_mapping[ForeignKey] = prepare
+        self.type_mapping[OneToOneField] = prepare
         return self._make(commit=False, **attrs)
 
     def get_fields(self):

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -197,6 +197,14 @@ class MommyCreatesAssociatedModels(TestCase):
         self.assertEqual(Person.objects.all().count(), 0)
         self.assertEqual(Dog.objects.all().count(), 0)
 
+    def test_prepare_one_to_one_should_not_persist_one_object(self):
+        lonely_person = mommy.prepare(LonelyPerson)
+
+        # makes sure database is clean
+        self.assertEqual(LonelyPerson.objects.all().count(), 0)
+        self.assertTrue(isinstance(lonely_person.only_friend, Person))
+        self.assertEqual(Person.objects.all().count(), 0)
+
     def test_create_one_to_one(self):
         lonely_person = mommy.make(LonelyPerson)
 


### PR DESCRIPTION
This change fixes `mommy.prepare` so that it won't persist an instance when there is a OneToOneField in the model. This problem and the solution is defined in issue #153 by @bahaddinyasar

It was already the case for ForeignKey fields, this is just an addition for the OneToOneField.
