### PR TITLE
Make a 2.6 compatability change

### DIFF
--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -72,8 +72,9 @@ def foreign_key(recipe):
 
 
 def seq(value, increment_by=1):
-    for n in itertools.count(increment_by, increment_by):
-        yield value + type(value)(n)
+    for n in itertools.count(1):
+        yield value + increment_by * type(value)(n)
+
 
 class related(object):
     def __init__(self, *args):


### PR DESCRIPTION
* itertools.count() only takes one argument in Python 2.6
* Python 2.6 is nice to support since it's part of the CentOS dist,
  CentOS being slow moving, but rock solid.