### PR TITLE
Repair BooleanField so random True/False value is assigned

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -271,7 +271,8 @@ class Mommy(object):
                 continue
 
             if all([field.name not in model_attrs, field.name not in self.rel_fields, field.name not in self.attr_mapping]):
-                if not issubclass(field.__class__, Field) or field.has_default() or field.blank:
+                # Django is quirky in that BooleanFields are always "blank", but have no default default.
+                if not issubclass(field.__class__, Field) or field.has_default() or (field.blank and not isinstance(field, BooleanField)):
                     continue
 
             if isinstance(field, ManyToManyField):

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -46,6 +46,7 @@ class Person(models.Model):
     gender = models.CharField(max_length=1, choices=GENDER_CH)
     happy = models.BooleanField(default=True)
     unhappy = models.BooleanField(default=False)
+    bipolar = models.BooleanField()
     name = models.CharField(max_length=30)
     nickname = models.SlugField(max_length=36)
     age = models.IntegerField()


### PR DESCRIPTION
I realized that I had moved master, and so I'm re-opening this pull request from a feature branch.

Discussion to date:

vandersonmota said:  I don't think we should force only for this special case, because it breaks the expectation that blanks and null fields will be ignored by default.
Instead, #148 should provide a way to specify when you want mommy to randomly fill blank/null fields when done.

David said:  Hmm --- the problem is that currently, the default behavior is not merely unexpected, but generates an error. Django has already made the choice to break the expectation; we're just living with it.

A settings variable?

(My use case is to write a single unit test which cycles through all models, and attempts to save and retrieve an instance of the model, w/o regard to the model. Having to explicitly specify behavior ONLY for Boolean fields to get it to work seems to break expectations as well.  I'd be glad with any approach in which tests pass with the bipolar variable.)
