### PR TITLE
Fix relations updating sequences

### DIFF
--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -39,7 +39,7 @@ class Recipe(object):
                 recipe_attrs = mommy.filter_rel_attrs(k, **a)
                 mapping[k] = v.recipe.make(**recipe_attrs)
             elif isinstance(v, related):
-                mapping[k] = v.prepare()
+                mapping[k] = v.make()
         mapping.update(new_attrs)
         mapping.update(rel_fields_attrs)
         return mapping
@@ -97,10 +97,11 @@ class related(object):
             else:
                 raise TypeError('Not a recipe')
 
-    def prepare(self):
+    def make(self):
         """
             Django related manager saves related set.
-            No need to persist at first
+            We need to save immediately to 
+            preserve iterators
         """
-        return [m.prepare() for m in self.related]
+        return [m.make() for m in self.related]
 

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -212,6 +212,15 @@ class DummyUniqueIntegerFieldModel(models.Model):
     value = models.IntegerField(unique=True)
 
 
+class Cake(models.Model):
+    pass
+
+
+class Ingredient(models.Model):
+    amount = models.IntegerField()
+    food_type = models.CharField(max_length=20)
+    cake = models.ForeignKey(Cake, related_name="ingredients")
+
 if VERSION < (1, 4):
     class DummyIPAddressFieldModel(models.Model):
         ipv4_field = models.IPAddressField()  # Deprecated in Django 1.7

--- a/test/generic/mommy_recipes.py
+++ b/test/generic/mommy_recipes.py
@@ -54,8 +54,6 @@ other_dog_unicode = Recipe(Dog,
     owner = foreign_key(u('person'))
 )
 
-dummy_related_unique = Recipe
-
 dummy_unique_field = Recipe(DummyUniqueIntegerFieldModel,
     value = seq(10),
 )

--- a/test/generic/mommy_recipes.py
+++ b/test/generic/mommy_recipes.py
@@ -3,9 +3,10 @@
 #ATTENTION: Recipes defined for testing purposes only
 from decimal import Decimal
 from model_mommy.recipe import Recipe, foreign_key, seq
+from itertools import cycle
 from model_mommy.recipe import related
 from model_mommy.timezone import now
-from test.generic.models import Person, Dog, DummyDefaultFieldsModel, DummyUniqueIntegerFieldModel
+from test.generic.models import Person, Dog, DummyDefaultFieldsModel, DummyUniqueIntegerFieldModel, Cake, Ingredient
 
 from six import u
 
@@ -53,10 +54,23 @@ other_dog_unicode = Recipe(Dog,
     owner = foreign_key(u('person'))
 )
 
+dummy_related_unique = Recipe
+
 dummy_unique_field = Recipe(DummyUniqueIntegerFieldModel,
     value = seq(10),
 )
 
 dog_lady = Recipe(Person,
     dog_set = related('dog', other_dog)
+)
+
+food_types = ["oranges", "lemons", "baking flower", "sugar"]
+
+ingredient_recipe = Recipe(Ingredient,
+    amount = seq(1),
+    food_type = cycle(food_types)
+)
+
+cake_recipe = Recipe(Cake,
+    ingredients=related(ingredient_recipe, ingredient_recipe, ingredient_recipe, ingredient_recipe)
 )

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -9,7 +9,7 @@ from model_mommy import mommy
 from model_mommy.recipe import Recipe, foreign_key, RecipeForeignKey
 from model_mommy.timezone import now
 from model_mommy.exceptions import InvalidQuantityException, RecipeIteratorEmpty
-from test.generic.models import Person, DummyNumbersModel, DummyBlankFieldsModel, Dog
+from test.generic.models import Person, DummyNumbersModel, DummyBlankFieldsModel, Dog, Cake, Ingredient
 
 
 class TestDefiningRecipes(TestCase):
@@ -467,3 +467,11 @@ class TestIterators(TestCase):
         self.assertEqual(
             r.make().blank_text_field,
             "not an iterator, so don't iterate!")
+
+    def test_related_iterators(self):
+        cake = mommy.make_recipe('test.generic.cake_recipe')
+        ingredients_amount = cake.ingredients.count()
+        i_amount = cake.ingredients.all().values_list("amount").distinct().count()
+        self.assertEqual(ingredients_amount, i_amount)
+        i_types = cake.ingredients.all().values_list("food_type").distinct().count()
+        self.assertEqual(ingredients_amount, i_amount)


### PR DESCRIPTION
before if you used seq or cycle in a related field in a recipe they didn't get updated. This meant I was hitting collisions in unique fields. If we actually create them individually when we create the recipe rather than creating them on save of the parent, we get round this.

have been loving using model_mommy, thanks for your work!