### PR TITLE
Change get_url to generate URL with trailing splash.

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -114,7 +114,7 @@ def gen_boolean():
 
 
 def gen_url():
-    return u'http://www.%s.com' % gen_string(30)
+    return u'http://www.%s.com/' % gen_string(30)
 
 
 def gen_email():


### PR DESCRIPTION
URLField in django by default force to store url with trailing slash in the end.
Let's generate url with tailing slash that after save or update value is not changed.

To avoid problems like this:

`AssertionError: u'http://www.BskxixnfuHpzmpjKTsuoSCdNBHdOdV.com' != u'http://www.BskxixnfuHpzmpjKTsuoSCdNBHdOdV.com/'`
