### PR TITLE
Use list rather than set (Python 2.6 compatibility)

### DIFF
--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -84,7 +84,7 @@ def foreign_key(recipe):
 
 
 def seq(value, increment_by=1):
-    if type(value) in {datetime.datetime, datetime.date,  datetime.time}:
+    if type(value) in [datetime.datetime, datetime.date,  datetime.time]:
         if type(value) is datetime.date:
             date = datetime.datetime.combine(value, datetime.datetime.now().time())
         elif type(value) is datetime.time:


### PR DESCRIPTION
Curly braces as a shorthand for set is a Python 2.7 feature. Changing to a list solves the issue.

I also suggest setting up a Tox build for Python 2.6.
