### PR TITLE
Minor Travis config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
       env: DJANGO_VERSION=1.6
     - python: 3.4
       env: DJANGO_VERSION=1.7
-before_install:
-  - sudo apt-get update && sudo apt-get build-dep python-imaging
 install:
    # Install whatever version of Django that's listed above
    # Travis is currently working on

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
 install:
    # Install whatever version of Django that's listed above
    # Travis is currently working on
- - pip install -q Django==$DJANGO_VERSION --use-mirrors
- - pip install -q Pillow --use-mirrors
- - pip install -r requirements.txt
+ - travis_retry pip install -q Django==$DJANGO_VERSION --use-mirrors
+ - travis_retry pip install -r requirements.txt
 script: python runtests.py


### PR DESCRIPTION
I noticed that the Travis badge was showing an error, and it seems that was due to pip timing out on one of the builds. I've run into this on a couple of other projects, and have handled it there by wrapping install commands with `travis_retry` (more info on that [here](http://docs.travis-ci.com/user/build-timeouts/#Timeouts-installing-dependencies)).

I also saw that Travis is still installing Pillow, even though the tests no longer depend on it, and so I pulled that from the config file as well.