### PR TITLE
Issue #216

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ share/
 .idea
 .tox
 build/
+lib64
+pyvenv.cfg

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -323,7 +323,7 @@ class Mommy(object):
     def m2m_value(self, field):
         if field.name in self.rel_fields:
             return self.generate_value(field)
-        if not self.make_m2m or field.null:
+        if not self.make_m2m or field.null and not field.fill_optional:
             return []
         return self.generate_value(field)
 

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -365,8 +365,6 @@ class FillNullsTestCase(TestCase):
         classroom = mommy.make(Classroom, make_m2m=False, _fill_optional=True)
         self.assertEqual(classroom.students.count(), 0)
 
-    # test_nullable_many_to_many_is_not_created_even_if_flagged_and_not_fill_optional in line 252
-    
 
 class SkipBlanksTestCase(TestCase):
     def test_skip_blank(self):

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -361,6 +361,12 @@ class FillNullsTestCase(TestCase):
         classroom = mommy.make(Classroom, make_m2m=True, _fill_optional=True)
         self.assertEqual(classroom.students.count(), 5)
 
+    def test_nullable_many_to_many_is_not_created_if_not_flagged_and_fill_optional(self):
+        classroom = mommy.make(Classroom, make_m2m=False, _fill_optional=True)
+        self.assertEqual(classroom.students.count(), 0)
+
+    # test_nullable_many_to_many_is_not_created_even_if_flagged_and_not_fill_optional in line 252
+    
 
 class SkipBlanksTestCase(TestCase):
     def test_skip_blank(self):

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -350,6 +350,18 @@ class SkipNullsTestCase(TestCase):
         self.assertEqual(dummy.null_integer_field, None)
 
 
+class FillNullsTestCase(TestCase):
+    def test_create_nullable_many_to_many_if_flagged_and_fill_field_optional(
+        self):
+        classroom = mommy.make(Classroom, make_m2m=True, _fill_optional=[
+            'students'])
+        self.assertNotEqual(classroom.students.count(), 0)
+
+    def test_create_nullable_many_to_many_if_flagged_and_fill_optional(self):
+        classroom = mommy.make(Classroom, make_m2m=True, _fill_optional=True)
+        self.assertNotEqual(classroom.students.count(), 0)
+
+
 class SkipBlanksTestCase(TestCase):
     def test_skip_blank(self):
         dummy = mommy.make(DummyBlankFieldsModel)

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -355,11 +355,11 @@ class FillNullsTestCase(TestCase):
         self):
         classroom = mommy.make(Classroom, make_m2m=True, _fill_optional=[
             'students'])
-        self.assertNotEqual(classroom.students.count(), 0)
+        self.assertEqual(classroom.students.count(), 5)
 
     def test_create_nullable_many_to_many_if_flagged_and_fill_optional(self):
         classroom = mommy.make(Classroom, make_m2m=True, _fill_optional=True)
-        self.assertNotEqual(classroom.students.count(), 0)
+        self.assertEqual(classroom.students.count(), 5)
 
 
 class SkipBlanksTestCase(TestCase):


### PR DESCRIPTION
Now m2m related objects are created if flag `make_m2m=True` is passed together with `_fill_optional=True` or `_fill_optional="name_of_field"`