### PR TITLE
Explicit pass empty middleware classes

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -37,6 +37,11 @@ def configure_settings(options):
             TEST_ROOT=join(dirname(__file__), 'test', 'generic', 'tests'),
         )
 
+        if django.VERSION >= (1, 7):
+            params.update(
+                MIDDLEWARE_CLASSES=tuple()
+            )
+
         # Force the use of timezone aware datetime and change Django's warning to
         # be treated as errors.
         if getattr(options, 'USE_TZ', False):


### PR DESCRIPTION
```
Django 1.7 changed the global defaults for the MIDDLEWARE_CLASSES. django.contrib.sessions.middleware.SessionMiddleware, django.contrib.auth.middleware.AuthenticationMiddleware, and django.contrib.messages.middleware.MessageMiddleware were removed from the defaults. If your project needs these middleware then you should configure this setting. 
```

As the project use none of these middleware, I'm passing explicity an empty tuple to django.settings in versions >= 1.7.