### PR TITLE
Fix generating models which have a 'next' method, but aren't iterators

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -241,10 +241,11 @@ class ModelFinder(object):
 
 
 def is_iterator(value):
-    if PY3:
-        return hasattr(value, '__next__')
-    else:
-        return hasattr(value, 'next')
+    try:
+        iter(value)
+        return not isinstance(value, string_types)
+    except TypeError:
+        return False
 
 
 class Mommy(object):

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -235,6 +235,17 @@ class DummyUniqueIntegerFieldModel(models.Model):
     value = models.IntegerField(unique=True)
 
 
+class ModelWithNext(models.Model):
+    attr = models.CharField(max_length=10)
+
+    def next(self):
+        return 'foo'
+
+
+class BaseModelForNext(models.Model):
+    fk = models.ForeignKey(ModelWithNext)
+
+
 if VERSION < (1, 4):
     class DummyIPAddressFieldModel(models.Model):
         ipv4_field = models.IPAddressField()  # Deprecated in Django 1.7

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -19,6 +19,7 @@ from test.generic.models import DummyNullFieldsModel, DummyBlankFieldsModel
 from test.generic.models import DummyDefaultFieldsModel, DummyMultipleInheritanceModel
 from test.generic.models import DummyGenericForeignKeyModel, NonAbstractPerson
 from test.generic.models import DummyEmptyModel
+from test.generic.models import ModelWithNext, BaseModelForNext
 
 
 class ModelFinderTest(TestCase):
@@ -427,6 +428,19 @@ class SkipDefaultsTestCase(TestCase):
         self.assertEqual(dummy.default_decimal_field, Decimal('0'))
         self.assertEqual(dummy.default_email_field, 'foo@bar.org')
         self.assertEqual(dummy.default_slug_field, 'a-slug')
+
+
+class MommyHandlesModelWithNext(TestCase):
+    def test_creates_instance_for_model_with_next(self):
+        instance = mommy.make(
+            BaseModelForNext,
+            fk=mommy.make(ModelWithNext),
+        )
+
+        self.assertTrue(instance.id)
+        self.assertTrue(instance.fk.id)
+        self.assertTrue(instance.fk.attr)
+        self.assertEqual('foo', instance.fk.next())
 
 
 if VERSION < (1, 4):


### PR DESCRIPTION
we stumpled on this because one of our models has a method called `next` (from `django-orderable`) which lead to mommy assigning `None` to this attribute. 

I changed the method to find out if a thing is an iterable. 