### PR TITLE
Bumping version to reflect latest.

### DIFF
--- a/model_mommy/__init__.py
+++ b/model_mommy/__init__.py
@@ -1,5 +1,5 @@
 #coding:utf-8
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 __title__ = 'model_mommy'
 __author__ = 'Vanderson Mota'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
Previous minor version was 1.2.4 at
SHA 7d01fc680ef7013a4ae68e6ea7d87c990dc55e82

Specifically the new commits would help solve this problem:

```
  File "/home/vagrant/envs/--/lib/python2.7/site-packages/model_mommy/mommy.py", line 79, in make
    return mommy.make(**attrs)
  File "/home/vagrant/envs/--/lib/python2.7/site-packages/model_mommy/mommy.py", line 262, in make
    return self._make(commit=True, **attrs)
  File "/home/vagrant/envs/--/lib/python2.7/site-packages/model_mommy/mommy.py", line 312, in _make
    model_attrs[field.name] = self.generate_value(field)
  File "/home/vagrant/envs/--/lib/python2.7/site-packages/model_mommy/mommy.py", line 420, in generate_value
    raise TypeError('%s is not supported by mommy.' % field.__class__)
TypeError: <class 'django.db.models.fields.BinaryField'> is not supported by mommy.
```

`pip` install-ing github:master works just fine.

I am unaware if the maintainer would like to cut a release right now, so I am willing to look into an alternative solution if advised.