### PR TITLE
Fixed related recipes objects saving for django 1.9

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -369,7 +369,11 @@ class Mommy(object):
 
     def _handle_one_to_many(self, instance, attrs):
         for k, v in attrs.items():
-            setattr(instance, k, v)
+            if django.VERSION >= (1, 9):
+                manager = getattr(instance, k)
+                manager.set(v, bulk=False)
+            else:
+                setattr(instance, k, v)
 
     def _handle_m2m(self, instance):
         for key, values in self.m2m_dict.items():


### PR DESCRIPTION
Fixed `ForeignKeyTestCase.test_related_models_recipes` test for Django 1.9+