### PR TITLE
Fix related() with nullable foreignkeys on django 1.9.

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -369,6 +369,9 @@ class Mommy(object):
 
     def _handle_one_to_many(self, instance, attrs):
         for k, v in attrs.items():
+            for value in v:
+                if not value.pk:
+                    value.save()
             if django.VERSION >= (1, 9):
                 manager = getattr(instance, k)
                 manager.set(v, bulk=False)

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -369,12 +369,9 @@ class Mommy(object):
 
     def _handle_one_to_many(self, instance, attrs):
         for k, v in attrs.items():
-            for value in v:
-                if not value.pk:
-                    value.save()
             if django.VERSION >= (1, 9):
                 manager = getattr(instance, k)
-                manager.set(v, bulk=False)
+                manager.set(v, bulk=False, clear=True)
             else:
                 setattr(instance, k, v)
 

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -257,6 +257,12 @@ class BaseModelForNext(models.Model):
 class BaseModelForList(models.Model):
     fk = FakeListField()
 
+class Movie(models.Model):
+    title = models.CharField(max_length=30)
+
+class CastMember(models.Model):
+    movie = models.ForeignKey(Movie, related_name='cast_members')
+    person = models.ForeignKey(Person)
 
 if VERSION < (1, 4):
     class DummyIPAddressFieldModel(models.Model):

--- a/test/generic/mommy_recipes.py
+++ b/test/generic/mommy_recipes.py
@@ -79,3 +79,9 @@ dog_lady = Recipe(Person,
 nullable_related = Recipe('generic.DummyBlankFieldsModel',
     dummynullfieldsmodel_set=related(Recipe('generic.DummyNullFieldsModel'))
 )
+
+cast_member = Recipe('generic.CastMember', person=foreign_key(person))
+
+movie_with_cast = Recipe('generic.Movie',
+    cast_members=related(cast_member, cast_member)
+)

--- a/test/generic/mommy_recipes.py
+++ b/test/generic/mommy_recipes.py
@@ -75,3 +75,7 @@ dummy_unique_field = Recipe(DummyUniqueIntegerFieldModel,
 dog_lady = Recipe(Person,
     dog_set = related('dog', other_dog)
 )
+
+nullable_related = Recipe('generic.DummyBlankFieldsModel',
+    dummynullfieldsmodel_set=related(Recipe('generic.DummyNullFieldsModel'))
+)

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -379,6 +379,10 @@ class ForeignKeyTestCase(TestCase):
         nullable = mommy.make_recipe('test.generic.nullable_related')
         self.assertEqual(nullable.dummynullfieldsmodel_set.count(), 1)
 
+    def test_chained_related(self):
+        movie = mommy.make_recipe('test.generic.movie_with_cast')
+        self.assertEqual(movie.cast_members.count(), 2)
+
 
 class M2MFieldTestCase(TestCase):
     def test_create_many_to_many(self):

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -375,6 +375,10 @@ class ForeignKeyTestCase(TestCase):
         self.assertEqual(lady.dog_set.all()[0].breed, 'Pug')
         self.assertEqual(lady.dog_set.all()[1].breed, 'Basset')
 
+    def test_nullable_related(self):
+        nullable = mommy.make_recipe('test.generic.nullable_related')
+        self.assertEqual(nullable.dummynullfieldsmodel_set.count(), 1)
+
 
 class M2MFieldTestCase(TestCase):
     def test_create_many_to_many(self):


### PR DESCRIPTION
Ensures that related models are saved before adding, using the same logic as is used for manytomany.