### PR TITLE
Add ability to plug in custom mommy implementations

### DIFF
--- a/docs/source/how_mommy_behaves.rst
+++ b/docs/source/how_mommy_behaves.rst
@@ -79,3 +79,26 @@ Examples:
     MOMMY_CUSTOM_FIELDS_GEN = {
         'test.generic.fields.CustomField': 'code.path.gen_func',
     }
+
+Customizing Mommy
+-------------
+
+In some rare cases, you might need to customize the way Mommy behaves.
+This can be achieved by creating a new class and specifying it in your settings files. It is likely that you will want to extend Mommy, however the minimum requirement is that the custom class have `make` and `prepare` functions.
+In order for the custom class to be used, make sure to use the `model_mommy.mommy.make` and `model_mommy.mommy.prepare` functions, and not `model_mommy.mommy.Mommy` directly.
+
+Examples:
+
+.. code-block:: python
+
+    # in the module code.path:
+    class CustomMommy(mommy.Mommy)
+        def get_fields(self):
+            return [
+                field
+                for field in super(CustomMommy, self).get_fields()
+                if not field isinstance CustomField
+            ]
+
+    # in your settings.py file:
+    MOMMY_CUSTOM_CLASS = 'code.path.CustomMommy'

--- a/model_mommy/exceptions.py
+++ b/model_mommy/exceptions.py
@@ -19,3 +19,11 @@ class AmbiguousModelName(Exception):
 
 class InvalidQuantityException(Exception):
     pass
+
+
+class CustomMommyNotFound(Exception):
+    pass
+
+
+class InvalidCustomMommy(Exception):
+    pass


### PR DESCRIPTION
It would be nice to be able to easily tweak mommy behaviour, without needing to monkey patch it.

We currently need to patch the `get_fields` method in order to properly create translated models (we are using https://github.com/edoburu/django-parler).

Hopefully these changes are suitable, but let me know if an alternative implementation would be preferred, or if there is anything not to your liking!