### PR TITLE
New generators register

### DIFF
--- a/docs/source/deprecation_warnings.rst
+++ b/docs/source/deprecation_warnings.rst
@@ -7,4 +7,4 @@ Because of the changes of model_mommy's API, the following methods are deprecate
   * `mommy.prepare_one` -> should use the method `mommy.prepare` instead
   * `mommy.make_many` -> should use the method `mommy.make` with the `_quantity` parameter instead
   * `mommy.make_many_from_recipe` -> should use the method `mommy.make_recipe` with the `_quantity` parameter instead
-  * `MOMMY_CUSTOM_FIELDS_GEN` -> should use the method `generators.add` instead
+  * `MOMMY_CUSTOM_FIELDS_GEN` -> should use the method `mommy.generators.add` instead

--- a/docs/source/deprecation_warnings.rst
+++ b/docs/source/deprecation_warnings.rst
@@ -7,3 +7,4 @@ Because of the changes of model_mommy's API, the following methods are deprecate
   * `mommy.prepare_one` -> should use the method `mommy.prepare` instead
   * `mommy.make_many` -> should use the method `mommy.make` with the `_quantity` parameter instead
   * `mommy.make_many_from_recipe` -> should use the method `mommy.make_recipe` with the `_quantity` parameter instead
+  * `MOMMY_CUSTOM_FIELDS_GEN` -> should use the method `generators.add` instead

--- a/docs/source/how_mommy_behaves.rst
+++ b/docs/source/how_mommy_behaves.rst
@@ -61,12 +61,12 @@ Examples:
 
 .. code-block:: python
 
-    from mommy import generators
+    from model_mommy import mommy
 
     def gen_func():
         return 'value'
 
-    generators.set('test.generic.fields.CustomField', gen_func)
+    mommy.generators.add('test.generic.fields.CustomField', gen_func)
 
 .. code-block:: python
 
@@ -75,9 +75,9 @@ Examples:
         return 'value'
 
     # in your tests.py file:
-    from mommy import generators
+    from model_mommy import mommy
 
-    generatos.set('test.generic.fields.CustomField', 'code.path.gen_func')
+    mommy.generatos.add('test.generic.fields.CustomField', 'code.path.gen_func')
 
 Customizing Mommy
 -----------------

--- a/docs/source/how_mommy_behaves.rst
+++ b/docs/source/how_mommy_behaves.rst
@@ -54,20 +54,19 @@ Custom fields
 -------------
 
 Model-mommy allows you to define generators methods for your custom fields or overrides its default generators.
-This could be achieved by specifing a dict on settings with keys defining the fields and values the generator functions.
+This could be achieved by specifing the field and generator function for the `generators.set` function.
 Both can be the real python objects imported in settings or just specified as import path string.
 
 Examples:
 
 .. code-block:: python
 
-    # on your settings.py file:
+    from mommy import generators
+
     def gen_func():
         return 'value'
 
-    MOMMY_CUSTOM_FIELDS_GEN = {
-        'test.generic.fields.CustomField': gen_func,
-    }
+    generators.set('test.generic.fields.CustomField', gen_func)
 
 .. code-block:: python
 
@@ -75,13 +74,13 @@ Examples:
     def gen_func():
         return 'value'
 
-    # in your settings.py file:
-    MOMMY_CUSTOM_FIELDS_GEN = {
-        'test.generic.fields.CustomField': 'code.path.gen_func',
-    }
+    # in your tests.py file:
+    from mommy import generators
+
+    generatos.set('test.generic.fields.CustomField', 'code.path.gen_func')
 
 Customizing Mommy
--------------
+-----------------
 
 In some rare cases, you might need to customize the way Mommy behaves.
 This can be achieved by creating a new class and specifying it in your settings files. It is likely that you will want to extend Mommy, however the minimum requirement is that the custom class have `make` and `prepare` functions.

--- a/docs/source/how_mommy_behaves.rst
+++ b/docs/source/how_mommy_behaves.rst
@@ -54,7 +54,7 @@ Custom fields
 -------------
 
 Model-mommy allows you to define generators methods for your custom fields or overrides its default generators.
-This could be achieved by specifing the field and generator function for the `generators.set` function.
+This could be achieved by specifing the field and generator function for the `generators.add` function.
 Both can be the real python objects imported in settings or just specified as import path string.
 
 Examples:

--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -1,12 +1,10 @@
-import django
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import (
     CharField, EmailField, SlugField, TextField, URLField,
     DateField, DateTimeField, TimeField,
-    AutoField, IntegerField, SmallIntegerField,
-    PositiveIntegerField, PositiveSmallIntegerField,
-    BooleanField, DecimalField, FloatField,
-    FileField, ImageField, Field, IPAddressField,
+    IntegerField, SmallIntegerField, PositiveIntegerField,
+    PositiveSmallIntegerField, BooleanField, DecimalField,
+    FloatField, FileField, ImageField, IPAddressField,
     ForeignKey, ManyToManyField, OneToOneField)
 
 from model_mommy.utils import import_if_str

--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -8,6 +8,9 @@ from django.db.models import (
     BooleanField, DecimalField, FloatField,
     FileField, ImageField, Field, IPAddressField,
     ForeignKey, ManyToManyField, OneToOneField)
+
+from model_mommy.utils import import_if_str
+
 try:
     from django.db.models import BigIntegerField
 except ImportError:
@@ -93,3 +96,14 @@ if JSONField:
 def get_type_mapping():
     mapping = default_mapping.copy()
     return mapping.copy()
+
+
+user_mapping = {}
+
+
+def add(field, func):
+    user_mapping[import_if_str(field)] = import_if_str(func)
+
+
+def get(field):
+    return user_mapping.get(field)

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -371,6 +371,8 @@ class Mommy(object):
             generator = self.type_mapping[ContentType]
         elif field.__class__ in self.type_mapping:
             generator = self.type_mapping[field.__class__]
+        elif generators.get(field.__class__):
+            generator = generators.get(field.__class__)
         else:
             raise TypeError('%s is not supported by mommy.' % field.__class__)
 

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -13,7 +13,7 @@ from django.core.files.images import ImageFile
 
 from six import text_type, string_types, binary_type
 
-from model_mommy import mommy, generators
+from model_mommy import mommy
 from model_mommy.random_gen import gen_related
 from test.generic import models
 from test.generic.generators import gen_value_string
@@ -365,7 +365,7 @@ class FillingImageFileField(TestCase):
 class FillingCustomFields(TestCase):
     def tearDown(self):
         delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
-        generators.add('test.generic.fields.CustomFieldWithGenerator', None)
+        mommy.generators.add('test.generic.fields.CustomFieldWithGenerator', None)
 
     def test_raises_unsupported_field_for_custom_field(self):
         """Should raise an exception if a generator is not provided for a custom field"""
@@ -395,13 +395,13 @@ class FillingCustomFields(TestCase):
 
     def test_uses_generator_defined_as_string_for_custom_field(self):
         """Should import and use the generator function used in the add method"""
-        generators.add('test.generic.fields.CustomFieldWithGenerator', 'test.generic.generators.gen_value_string')
+        mommy.generators.add('test.generic.fields.CustomFieldWithGenerator', 'test.generic.generators.gen_value_string')
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         self.assertEqual("value", obj.custom_value)
 
     def test_uses_generator_function_for_custom_foreignkey(self):
         """Should use the generator function passed as a value for the add method"""
-        generators.add('test.generic.fields.CustomForeignKey', gen_related)
+        mommy.generators.add('test.generic.fields.CustomForeignKey', gen_related)
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
         self.assertEqual('a@b.com', obj.custom_fk.email)
 

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -372,14 +372,14 @@ class FillingCustomFields(TestCase):
         self.assertRaises(TypeError, mommy.make, models.CustomFieldWithoutGeneratorModel)
 
     def test_uses_generator_defined_on_settings_for_custom_field(self):
-        """Should user the function defined in settings as a generator"""
+        """Should use the function defined in settings as a generator"""
         generator_dict = {'test.generic.fields.CustomFieldWithGenerator': gen_value_string}
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         self.assertEqual("value", obj.custom_value)
 
     def test_uses_generator_defined_as_string_on_settings_for_custom_field(self):
-        """Should import and use the function defined in the import path defined in settings"""
+        """Should import and use the function present in the import path defined in settings"""
         generator_dict = {'test.generic.fields.CustomFieldWithGenerator':
                                 'test.generic.generators.gen_value_string'}
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -364,7 +364,8 @@ class FillingImageFileField(TestCase):
 
 class FillingCustomFields(TestCase):
     def tearDown(self):
-        delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
+        if hasattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN'):
+            delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
         mommy.generators.add('test.generic.fields.CustomFieldWithGenerator', None)
 
     def test_raises_unsupported_field_for_custom_field(self):


### PR DESCRIPTION
`set` actually shadows a built-in function name, so I changed it to `add`.

Thinking about it a little more I have a small suggestion, we could leave the `generators.py` for mommy's own generators and add a method in the mommy module to enable the user to define custom generators.

Something like:
`from model_mommy import mommy`
`mommy.add_generator(field, gen_fun)`
`mommy.remove_generator(field)`