### PR TITLE
Add support for HStoreFields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ services:
   - postgresql
 before_script:
   - psql -U postgres -c "create extension postgis"
+  - psql -U postgres -c "create extension hstore"
   - psql -c 'create database model_mommy;' -U postgres
   - psql -c 'create database model_mommy_test;' -U postgres
 script:

--- a/docs/source/how_mommy_behaves.rst
+++ b/docs/source/how_mommy_behaves.rst
@@ -49,6 +49,7 @@ Currently supported fields
 * ForeignKey, OneToOneField, ManyToManyField (even with through model)
 * DateField, DateTimeField, TimeField
 * FileField, ImageField
+* JSONField, ArrayField, HStoreField
 
 Custom fields
 -------------

--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -44,6 +44,11 @@ try:
 except ImportError:
     JSONField = None
 
+try:
+    from django.contrib.postgres.fields import HStoreField
+except ImportError:
+    HStoreField = None
+
 from . import random_gen
 default_mapping = {
     ForeignKey: random_gen.gen_related,
@@ -89,6 +94,8 @@ if ArrayField:
     default_mapping[ArrayField] = random_gen.gen_array
 if JSONField:
     default_mapping[JSONField] = random_gen.gen_json
+if HStoreField:
+    default_mapping[HStoreField] = random_gen.gen_hstore
 
 
 def get_type_mapping():

--- a/model_mommy/random_gen.py
+++ b/model_mommy/random_gen.py
@@ -213,6 +213,9 @@ def gen_json():
     return {}
 
 
+def gen_hstore():
+    return {}
+
 def _fk_model(field):
     try:
         return ('model', field.related_model)

--- a/runtests.py
+++ b/runtests.py
@@ -6,13 +6,11 @@ from optparse import OptionParser
 import warnings
 import django
 
-
 def parse_args():
     parser = OptionParser()
     parser.add_option('--use-tz', dest='USE_TZ', action='store_true')
     parser.add_option('--postgresql', dest='USE_POSTGRESQL', action='store_true')
     return parser.parse_args()
-
 
 def configure_settings(options):
     from django.conf import settings
@@ -65,12 +63,36 @@ def configure_settings(options):
 
     return settings
 
+if django.VERSION >= (1, 8):
+    # We only need this if HstoreFields are a possibility
+    from django.db.backends.signals import connection_created
+    from django.test.runner import DiscoverRunner
+
+    def create_hstore(sender, **kwargs):
+        conn = kwargs.get('connection')
+        if conn is not None:
+            cursor = conn.cursor()
+            cursor.execute('CREATE EXTENSION IF NOT EXISTS HSTORE')
+
+    class PostgresRunner(DiscoverRunner):
+        """Create HStore extension before test database is created"""
+
+        def setup_databases(self):
+            connection_created.connect(create_hstore)
+            result = super(PostgresRunner, self).setup_databases()
+            connection_created.disconnect(create_hstore)
+            return result
+
 
 def get_runner(settings):
     '''
     Asks Django for the TestRunner defined in settings or the default one.
     '''
     from django.test.utils import get_runner
+    if getattr(options, 'USE_POSTGRESQL', False) and django.VERSION >= (1, 8):
+        setattr(settings, 'INSTALLED_APPS',
+                ['django.contrib.postgres']
+                + list(getattr(settings, 'INSTALLED_APPS')))
     if django.VERSION >= (1, 7):
         #  I suspect this will not be necessary in next release after 1.7.0a1:
         #  See https://code.djangoproject.com/ticket/21831
@@ -86,7 +108,10 @@ def get_runner(settings):
 def runtests(options=None, labels=None):
     settings = configure_settings(options)
     if django.VERSION >= (1, 8):
-        settings.TEST_RUNNER='django.test.runner.DiscoverRunner'
+        if getattr(options, 'USE_POSTGRESQL', False):
+            settings.TEST_RUNNER = 'runtests.PostgresRunner'
+        else:
+            settings.TEST_RUNNER = 'django.test.runner.DiscoverRunner'
         if not labels:
             labels = ['test.generic']
     else:

--- a/test/generic/models.py
+++ b/test/generic/models.py
@@ -96,6 +96,13 @@ class Person(models.Model):
         # New at Django 1.9
         pass
 
+    try:
+        from django.contrib.postgres.fields import HStoreField
+        hstore_data = HStoreField()
+    except ImportError:
+        # New at Django 1.8
+        pass
+
     #backward compatibilty with Django 1.1
     try:
         wanted_games_qtd = models.BigIntegerField()

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -53,6 +53,11 @@ try:
 except ImportError:
     JSONField = None
 
+try:
+    from django.contrib.postgres.fields import HStoreField
+except ImportError:
+    HStoreField = None
+
 from django.core.validators import validate_ipv4_address
 try:
     from django.core.validators import validate_ipv6_address, validate_ipv46_address
@@ -201,16 +206,21 @@ class UUIDFieldsFilling(FieldFillingTestCase):
 class ArrayFieldsFilling(FieldFillingTestCase):
 
     if ArrayField:
-        def test_fill_ArrayField_with_uuid_object(self):
+        def test_fill_ArrayField_with_empty_array(self):
             self.assertEqual(self.person.acquaintances, [])
 
 
 class JSONFieldsFilling(FieldFillingTestCase):
 
     if JSONField:
-        def test_fill_ArrayField_with_uuid_object(self):
+        def test_fill_JSONField_with_empty_dict(self):
             self.assertEqual(self.person.data, {})
 
+class HStoreFieldsFilling(FieldFillingTestCase):
+
+    if HStoreField:
+        def test_fill_HStoreField_with_empty_dict(self):
+            self.assertEqual(self.person.hstore_data, {})
 
 class FillingIntFields(TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ basepython =
     py35: python3.5
     py34: python3.4
 deps =
-    Pillow>=2.3.1
+    py26: Pillow>=2.3.1,<4.0.0
+    py{27,34,35}: Pillow>=2.3.1
     mock==1.0.1
     six>=1.3.0
     django-test-without-migrations


### PR DESCRIPTION
HStoreField can be handled in the same manner as JSONField. Testing is a bit trickier since we need to install the hstore extension on the test postgres database before the models themselves are created. 

- Generator for hstore fields matching how JSONFields are currently handled.
- Updated tests to create hstore extension when needed and test hstorefield filling
- Update docs-supported fields list to include postgres specific fields