### PR TITLE
Pin-points supported Django versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django
+django>=1.6.0,<1.11
 six

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     include_package_data=True,  # declarations in MANIFEST.in
     install_requires=open(join(dirname(__file__), 'requirements.txt')).readlines(),
     tests_require=[
-        'django',
+        'django>=1.6,<1.11',
         'pil',
         'tox',
         'mock'


### PR DESCRIPTION
Hi,

A small improvement: requirements, for test and installation, should be pin-pointed to supported versions to avoid problems.

The commit pin-points Django to claimed supported versions >= 1.6, < 1.11 since 1.10 support was added in version 1.3.0 and 1.5 support was dropped in version 1.3.1.