### PR TITLE
Closes #303: Clean or use temp files for FileFields

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -235,6 +235,13 @@ File: test_model.py ::
                 owner__name='Bob'
             )
 
+Creating Files
+--------------
+
+Mommy does not creates files for FileField types. If you need to have the files created, you can pass the flag `_create_files=True` (defaults to `False`) to either `mommy.make` or `mommy.make_receipe`.
+
+**Important**: Mommy does not do any kind of file clean up, so it's up to you to delete the files created by it.
+
 
 Non persistent objects
 ----------------------

--- a/docs/source/deprecation_warnings.rst
+++ b/docs/source/deprecation_warnings.rst
@@ -8,3 +8,4 @@ Because of the changes of model_mommy's API, the following methods are deprecate
   * `mommy.make_many` -> should use the method `mommy.make` with the `_quantity` parameter instead
   * `mommy.make_many_from_recipe` -> should use the method `mommy.make_recipe` with the `_quantity` parameter instead
   * `MOMMY_CUSTOM_FIELDS_GEN` -> should use the method `mommy.generators.add` instead
+  * model_mommy does not create file automagically anymore. To enable it, you have to pass the parameter `_create_files` to `mommy.make` or `mommy.make_recipe` method.

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from os.path import abspath
 from tempfile import gettempdir
 
+from unittest import skipUnless
 from django.test import TestCase
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -343,30 +344,27 @@ class FillingFileField(TestCase):
         self.dummy.file_field.delete()
 
 
-# skipUnless not available in Django 1.2
-# @skipUnless(has_pil, "PIL is required to test ImageField")
+@skipUnless(models.has_pil, "PIL is required to test ImageField")
 class FillingImageFileField(TestCase):
 
     def setUp(self):
         path = mommy.mock_file_jpeg
         self.fixture_img_file = ImageFile(open(path))
 
-    if models.has_pil:
-        def test_filling_image_file_field(self):
-            self.dummy = mommy.make(models.DummyImageFieldModel)
-            field = models.DummyImageFieldModel._meta.get_field('image_field')
-            self.assertIsInstance(field, django_models.ImageField)
-            import time
-            path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
-
-            # These require the file to exist in earlier versions of Django
-            self.assertEqual(abspath(self.dummy.image_field.path), abspath(path))
-            self.assertTrue(self.dummy.image_field.width)
-            self.assertTrue(self.dummy.image_field.height)
-
     def tearDown(self):
         self.dummy.image_field.delete()
 
+    def test_filling_image_file_field(self):
+        self.dummy = mommy.make(models.DummyImageFieldModel)
+        field = models.DummyImageFieldModel._meta.get_field('image_field')
+        self.assertIsInstance(field, django_models.ImageField)
+        import time
+        path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
+
+        # These require the file to exist in earlier versions of Django
+        self.assertEqual(abspath(self.dummy.image_field.path), abspath(path))
+        self.assertTrue(self.dummy.image_field.width)
+        self.assertTrue(self.dummy.image_field.height)
 
 class FillingCustomFields(TestCase):
     def tearDown(self):

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -360,7 +360,7 @@ class FillingImageFileField(TestCase):
         self.dummy.image_field.delete()
 
     def test_filling_image_file_field(self):
-        self.dummy = mommy.make(models.DummyImageFieldModel)
+        self.dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
         field = models.DummyImageFieldModel._meta.get_field('image_field')
         self.assertIsInstance(field, django_models.ImageField)
         import time

--- a/test/generic/tests/test_filling_fields.py
+++ b/test/generic/tests/test_filling_fields.py
@@ -331,8 +331,11 @@ class FillingFileField(TestCase):
         path = mommy.mock_file_txt
         self.fixture_txt_file = File(open(path))
 
+    def tearDown(self):
+        self.dummy.file_field.delete()
+
     def test_filling_file_field(self):
-        self.dummy = mommy.make(models.DummyFileFieldModel)
+        self.dummy = mommy.make(models.DummyFileFieldModel, _create_files=True)
         field = models.DummyFileFieldModel._meta.get_field('file_field')
         self.assertIsInstance(field, django_models.FileField)
         import time
@@ -340,8 +343,10 @@ class FillingFileField(TestCase):
 
         self.assertEqual(abspath(self.dummy.file_field.path), abspath(path))
 
-    def tearDown(self):
-        self.dummy.file_field.delete()
+    def test_does_not_create_file_if_not_flagged(self):
+        self.dummy = mommy.make(models.DummyFileFieldModel)
+        with self.assertRaises(ValueError):
+            self.dummy.file_field.path  # Django raises ValueError if file does not exist
 
 
 @skipUnless(models.has_pil, "PIL is required to test ImageField")
@@ -365,6 +370,12 @@ class FillingImageFileField(TestCase):
         self.assertEqual(abspath(self.dummy.image_field.path), abspath(path))
         self.assertTrue(self.dummy.image_field.width)
         self.assertTrue(self.dummy.image_field.height)
+
+    def test_does_not_create_file_if_not_flagged(self):
+        self.dummy = mommy.make(models.DummyImageFieldModel)
+        with self.assertRaises(ValueError):
+            self.dummy.image_field.path  # Django raises ValueError if file does not exist
+
 
 class FillingCustomFields(TestCase):
     def tearDown(self):


### PR DESCRIPTION
Fixes #303 

@robertfw maybe you'll be interested about this PR too ;)

@vandersonmota my proposal to fix the file creation bug is the same we adopted with M2M fields. The default behaviour now is that model mommy **does not create** files for file fields. But, if the developer wants to, there is a new flag called `_create_files` he/she can pass to `mommy.make`.

Since this introduces new break changes to older versions, we'll need to add some docs on this. If you're good with my proposal, I can write it.