### PR TITLE
Change `ForeignObjectRel.to` references to `ForeignObjectRel.model`

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -387,7 +387,7 @@ class Mommy(object):
             generator = self.attr_mapping[field.name]
         elif getattr(field, 'choices'):
             generator = random_gen.gen_from_choices(field.choices)
-        elif isinstance(field, ForeignKey) and issubclass(self._remote_field(field).to, ContentType):
+        elif isinstance(field, ForeignKey) and issubclass(self._remote_field(field).model, ContentType):
             generator = self.type_mapping[ContentType]
         elif generators.get(field.__class__):
             generator = generators.get(field.__class__)


### PR DESCRIPTION
Fixes this deprecation warning:
> RemovedInDjango20Warning: Usage of ForeignObjectRel.to attribute has been deprecated. Use the model attribute instead.

Looks like it's safe to just simply change this from `.to` to `.model`, since Django 1.8 provides an alias (see [here](https://github.com/django/django/blob/1.8/django/db/models/fields/related.py#L1291)).

I should have done more extensive testing before requesting a new PyPI version. Sorry :(