### PR TITLE
imagefield behavior

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -7,6 +7,8 @@ TODO
 - Drops support for Django < 1.8
 - Fix deprecation warnings for Django 1.11
 - Avoid touching the DB on prepare()
+- Flag `_create_files=True` needed to create ImageFieldFile in ImageFields,
+otherwise you'll get a `<ImageFieldFile: None>`
 
 1.3.2
 -----


### PR DESCRIPTION
When I upgraded model_mommy, my tests that used the files created in ImageFields started to break because the field was filled with a `<ImageFieldFile: None>` instance.
`_create_files` flag is needed to use old behavior.