### PR TITLE
Remove wrong parameter, fixes #344

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -342,7 +342,7 @@ class Mommy(object):
         for k, v in attrs.items():
             if django.VERSION >= (1, 9):
                 manager = getattr(instance, k)
-                manager.set(v, bulk=False, clear=True)
+                manager.set(v, clear=True)
             else:
                 setattr(instance, k, v)
 

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -14,7 +14,7 @@ from django.db.models import ForeignKey, ManyToManyField, OneToOneField, Field, 
 if django.VERSION >= (1, 9):
     from django.db.models.fields.related import ReverseManyToOneDescriptor as ForeignRelatedObjectsDescriptor
 else:
-    from django.db.models.fields.related import ForeignRelatedObjectsDescriptor
+    from django.db.models.fields.related import ForeignRelatedObjectsDescriptor, ManyRelatedObjectsDescriptor, ReverseManyRelatedObjectsDescriptor
 from django.db.models.fields.proxy import OrderWrt
 
 from . import generators
@@ -280,7 +280,10 @@ class Mommy(object):
         one_to_many_keys = {}
         for k in tuple(attrs.keys()):
             field = getattr(self.model, k, None)
-            if isinstance(field, ForeignRelatedObjectsDescriptor):
+            related_objects_descriptors = (ForeignRelatedObjectsDescriptor,)
+            if django.VERSION < (1, 9): # in django 1.8, these two additional classes weren't subclasses of ForeignRelatedObjectsDescriptor
+                related_objects_descriptors = (ForeignRelatedObjectsDescriptor, ManyRelatedObjectsDescriptor, ReverseManyRelatedObjectsDescriptor)
+            if isinstance(field, related_objects_descriptors):
                 one_to_many_keys[k] = attrs.pop(k)
 
         instance = self.model(**attrs)

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -216,6 +216,12 @@ class MommyCreatesAssociatedModels(TestCase):
         for person in models.Person.objects.all():
             self.assertEqual(person.name, 'john')
 
+    def test_access_related_name_of_m2m(self):
+        try:
+            mommy.make(models.Person, classroom_set=[mommy.make(models.Classroom)])
+        except TypeError:
+            self.fail('type error raised')
+
     def test_prepare_fk(self):
         dog = mommy.prepare(models.Dog)
         self.assertIsInstance(dog, models.Dog)


### PR DESCRIPTION
fixes #344

As described in that issue, django has two such set() methods, one with and one without the bulk parameter. model_mommy was calling the one without the parameter, and specifying it simply had no effect previously. django broke it by making the parameter list more explicit.

i couldn't get the tests running (i get a massive bunch of `django.db.utils.InterfaceError: Error binding parameter 15 - probably unsupported type.`), so there is no test and i have no idea whether that breaks anything (e.g. if in some circumstance, model_mommy uses the other type of manager which actually has that parameter), so lets see what travis says...