### PR TITLE
Fix type error -- Recipe.extend should return the same type

### DIFF
--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -75,7 +75,7 @@ class Recipe(object):
     def extend(self, **attrs):
         attr_mapping = self.attr_mapping.copy()
         attr_mapping.update(attrs)
-        return Recipe(self._model, **attr_mapping)
+        return type(self)(self._model, **attr_mapping)
 
 
 class RecipeForeignKey(object):

--- a/test/generic/mommy_recipes.py
+++ b/test/generic/mommy_recipes.py
@@ -71,6 +71,18 @@ extended_dog = dog.extend(
     breed = 'Super basset',
 )
 
+
+class SmallDogRecipe(Recipe):
+    pass
+
+
+small_dog = SmallDogRecipe(Dog)
+
+
+pug = small_dog.extend(
+    breed='Pug',
+)
+
 other_dog_unicode = Recipe(Dog,
     breed = 'Basset',
     owner = foreign_key(u('person'))

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -12,6 +12,7 @@ from model_mommy.recipe import Recipe, foreign_key, RecipeForeignKey, related
 from model_mommy.timezone import now, tz_aware
 from model_mommy.exceptions import InvalidQuantityException, RecipeIteratorEmpty
 from test.generic.models import TEST_TIME, Person, DummyNumbersModel, DummyBlankFieldsModel, Dog
+from test.generic.mommy_recipes import SmallDogRecipe, pug
 
 
 class TestDefiningRecipes(TestCase):
@@ -222,6 +223,9 @@ class TestExecutingRecipes(TestCase):
         # No side effects happened due to extension
         base_dog = mommy.make_recipe('test.generic.dog')
         self.assertEqual(base_dog.breed, 'Pug')
+
+    def test_extended_recipe_type(self):
+        self.assertIsInstance(pug, SmallDogRecipe)
 
     def test_save_related_instances_on_prepare_recipe(self):
         dog = mommy.prepare_recipe('test.generic.homeless_dog')


### PR DESCRIPTION
If you write a subclass of Recipe, for whatever reason, calling
the extend method on it will not return the same type, but always
Recipe. It should be expected that `extend` extends the current
type and returns a new instance of the same type.