### PR TITLE
Add option to automatically call refresh_from_db

### DIFF
--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -233,7 +233,8 @@ class Mommy(object):
             '_save_kwargs':_save_kwargs,
             '_refresh_after_create': _refresh_after_create,
         }
-        return self._make(**params, **attrs)
+        params.update(attrs)
+        return self._make(**params)
 
     def prepare(self, _save_related=False, **attrs):
         """Creates, but does not persist, an instance of the model

--- a/test/generic/tests/test_mommy.py
+++ b/test/generic/tests/test_mommy.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+import datetime
+
 from mock import patch
 from decimal import Decimal
 
@@ -9,9 +11,10 @@ from django.db.models.signals import m2m_changed
 from model_mommy import mommy
 from model_mommy import random_gen
 from model_mommy.exceptions import ModelNotFound, AmbiguousModelName, InvalidQuantityException
-from model_mommy.timezone import smart_datetime as datetime
+from model_mommy.timezone import smart_datetime
 
 from test.generic import models
+from test.generic.forms import DummyGenericIPAddressFieldForm
 
 
 class ModelFinderTest(TestCase):
@@ -474,7 +477,7 @@ class SkipDefaultsTestCase(TestCase):
         self.assertEqual(dummy.default_int_field, 123)
         self.assertEqual(dummy.default_float_field, 123.0)
         self.assertEqual(dummy.default_date_field, '2012-01-01')
-        self.assertEqual(dummy.default_date_time_field, datetime(2012, 1, 1))
+        self.assertEqual(dummy.default_date_time_field, smart_datetime(2012, 1, 1))
         self.assertEqual(dummy.default_time_field, '00:00:00')
         self.assertEqual(dummy.default_decimal_field, Decimal('0'))
         self.assertEqual(dummy.default_email_field, 'foo@bar.org')
@@ -504,7 +507,6 @@ class MommyHandlesModelWithList(TestCase):
         self.assertTrue(instance.id)
         self.assertEqual(["foo"], instance.fk)
 
-from test.generic.forms import DummyGenericIPAddressFieldForm
 
 class MommyGeneratesIPAdresses(TestCase):
     def test_create_model_with_valid_ips(self):
@@ -517,7 +519,6 @@ class MommyGeneratesIPAdresses(TestCase):
 
 
 class MommyAllowsSaveParameters(TestCase):
-
     def setUp(self):
         self.owner = mommy.make(models.Person)
 
@@ -528,3 +529,22 @@ class MommyAllowsSaveParameters(TestCase):
         dog1, dog2 = mommy.make(models.ModelWithOverridedSave, _save_kwargs={'owner': self.owner}, _quantity=2)
         self.assertEqual(self.owner, dog1.owner)
         self.assertEqual(self.owner, dog2.owner)
+
+
+class MommyAutomaticallyRefreshFromDB(TestCase):
+    def test_refresh_from_db_if_true(self):
+        person = mommy.make(models.Person, birthday='2017-02-01', _refresh_after_create=True)
+
+        self.assertEqual(person.birthday, datetime.date(2017, 2, 1))
+
+    def test_do_not_refresh_from_db_if_false(self):
+        person = mommy.make(models.Person, birthday='2017-02-01', _refresh_after_create=False)
+
+        self.assertEqual(person.birthday, '2017-02-01')
+        self.assertNotEqual(person.birthday, datetime.date(2017, 2, 1))
+
+    def test_do_not_refresh_from_db_by_default(self):
+        person = mommy.make(models.Person, birthday='2017-02-01')
+
+        self.assertEqual(person.birthday, '2017-02-01')
+        self.assertNotEqual(person.birthday, datetime.date(2017, 2, 1))

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -162,6 +162,7 @@ class TestDefiningRecipes(TestCase):
         except AttributeError as e:
             self.fail('%s' %e)
 
+
 class TestExecutingRecipes(TestCase):
     """
       Tests for calling recipes defined in mommy_recipes.py
@@ -187,7 +188,6 @@ class TestExecutingRecipes(TestCase):
         for dog in dogs:
             self.assertEqual(dog.breed, 'Pug')
             self.assertEqual(dog.owner, owner)
-
 
     def test_model_with_foreign_key_as_str(self):
         dog = mommy.make_recipe('test.generic.other_dog')


### PR DESCRIPTION
By default, the param `_refresh_after_create ` is `False`. If `True`, it will call `refresh_from_db` after creation.

Solves https://github.com/vandersonmota/model_mommy/issues/337. CC @jonashaag.