### PR TITLE
Enable seq method to be imported directly from model_mommy

### DIFF
--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -261,6 +261,25 @@ Sometimes, you have a field with an unique value and using `make` can cause rand
 
 This will append a counter to strings to avoid uniqueness problems and it will sum the counter with numerical values.
 
+Sequences can be used not only for recipes, but with `mommy.make` as well:
+
+.. code-block:: python
+
+
+    # it can be imported directly from model_mommy
+    from model_mommy import seq
+    from model_mommy import mommy
+
+    p = mommy.make('Person', name=seq('Joe'))
+    p.name
+    >>> 'Joe1'
+
+    people = mommy.make('Person', name=seq('Chad'), _quantity=3)
+    for person in people:
+        print(person.name)
+    >>> 'Chad1'
+    >>> 'Chad2'
+    >>> 'Chad3'
 
 You can also provide an optional `increment_by` argument which will modify incrementing behaviour. This can be an integer, float, Decimal or timedelta.
 

--- a/model_mommy/__init__.py
+++ b/model_mommy/__init__.py
@@ -3,3 +3,6 @@ __version__ = '1.6.0'
 __title__ = 'model_mommy'
 __author__ = 'Vanderson Mota'
 __license__ = 'Apache 2.0'
+
+
+from .recipe import seq

--- a/model_mommy/__init__.py
+++ b/model_mommy/__init__.py
@@ -5,4 +5,4 @@ __author__ = 'Vanderson Mota'
 __license__ = 'Apache 2.0'
 
 
-from .recipe import seq
+from .utils import seq

--- a/model_mommy/recipe.py
+++ b/model_mommy/recipe.py
@@ -3,26 +3,15 @@ from functools import wraps
 import inspect
 import itertools
 from . import mommy
-from .timezone import tz_aware
 from .exceptions import RecipeNotFound, RecipeIteratorEmpty
 
+# Enable seq to be imported from recipes
+from .utils import seq
+
 from six import string_types
-import datetime
-
-
-# Python 2.6.x compatibility code
-itertools_count = itertools.count
-try:
-    itertools_count(0, 1)
-except TypeError:
-    def count(start=0, step=1):
-        n = start
-        while True:
-            yield n
-            n += step
-    itertools_count =  count
 
 finder = mommy.ModelFinder()
+
 
 class Recipe(object):
     def __init__(self, _model, **attrs):
@@ -101,43 +90,6 @@ def foreign_key(recipe):
       will not be created during the recipe definition.
     """
     return RecipeForeignKey(recipe)
-
-
-def _total_secs(td):
-    """
-    python 2.6 compatible timedelta total seconds calculation
-    backport from
-    https://docs.python.org/2.7/library/datetime.html#datetime.timedelta.total_seconds
-    """
-    if hasattr(td, 'total_seconds'):
-        return td.total_seconds()
-    else:
-        #py26
-        return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10.0**6
-
-
-def seq(value, increment_by=1):
-    if type(value) in [datetime.datetime, datetime.date,  datetime.time]:
-        if type(value) is datetime.date:
-            date = datetime.datetime.combine(value, datetime.datetime.now().time())
-        elif type(value) is datetime.time:
-            date = datetime.datetime.combine(datetime.date.today(), value)
-        else:
-            date = value
-        # convert to epoch time
-        start = _total_secs((date - datetime.datetime(1970, 1, 1)))
-        increment_by = _total_secs(increment_by)
-        for n in itertools_count(increment_by, increment_by):
-            series_date = tz_aware(datetime.datetime.utcfromtimestamp(start + n))
-            if type(value) is datetime.time:
-                yield series_date.time()
-            elif type(value) is datetime.date:
-                yield series_date.date()
-            else:
-                yield series_date
-    else:
-        for n in itertools_count(increment_by, increment_by):
-            yield value + type(value)(n)
 
 
 class related(object):

--- a/model_mommy/utils.py
+++ b/model_mommy/utils.py
@@ -1,7 +1,22 @@
 # -*- coding: utf-8 -*-
 import importlib
+import datetime
+import itertools
 
+from .timezone import tz_aware
 from six import string_types
+
+# Python 2.6.x compatibility code
+itertools_count = itertools.count
+try:
+    itertools_count(0, 1)
+except TypeError:
+    def count(start=0, step=1):
+        n = start
+        while True:
+            yield n
+            n += step
+    itertools_count = count
 
 
 def import_if_str(import_string_or_obj):
@@ -27,3 +42,39 @@ def import_from_str(import_string):
     module = importlib.import_module(path)
     return getattr(module, field_name)
 
+
+def _total_secs(td):
+    """
+    python 2.6 compatible timedelta total seconds calculation
+    backport from
+    https://docs.python.org/2.7/library/datetime.html#datetime.timedelta.total_seconds
+    """
+    if hasattr(td, 'total_seconds'):
+        return td.total_seconds()
+    else:
+        #py26
+        return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10.0**6
+
+
+def seq(value, increment_by=1):
+    if type(value) in [datetime.datetime, datetime.date,  datetime.time]:
+        if type(value) is datetime.date:
+            date = datetime.datetime.combine(value, datetime.datetime.now().time())
+        elif type(value) is datetime.time:
+            date = datetime.datetime.combine(datetime.date.today(), value)
+        else:
+            date = value
+        # convert to epoch time
+        start = _total_secs((date - datetime.datetime(1970, 1, 1)))
+        increment_by = _total_secs(increment_by)
+        for n in itertools_count(increment_by, increment_by):
+            series_date = tz_aware(datetime.datetime.utcfromtimestamp(start + n))
+            if type(value) is datetime.time:
+                yield series_date.time()
+            elif type(value) is datetime.date:
+                yield series_date.date()
+            else:
+                yield series_date
+    else:
+        for n in itertools_count(increment_by, increment_by):
+            yield value + type(value)(n)

--- a/test/generic/tests/test_recipes.py
+++ b/test/generic/tests/test_recipes.py
@@ -33,6 +33,15 @@ class TestDefiningRecipes(TestCase):
           **self.recipe_attrs
         )
 
+    def test_import_seq_from_mommy(self):
+        """
+            Import seq method directly from mommy module
+        """
+        try:
+            from model_mommy import seq
+        except ImportError:
+            self.fail('{} raised'.format(ImportError.__name__))
+
     def test_flat_model_make_recipe_with_the_correct_attributes(self):
         """
           A 'flat model' means a model without associations, like


### PR DESCRIPTION
Enable `seq` method to be imported directly from `model_mommy` module and improve its documentation with examples using `mommy.make`. Issue #371 